### PR TITLE
Add end-of-game message and display functionality

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,7 +63,7 @@ fn physics(mut world: World) -> Result<World>{
     }
     if world.next_right < world.map[0].1 {
         world.map[0].1 -= 1;
-    } 
+    }
     // TODO: below randoms may 1) go outside of range
     if world.next_left == world.map[0].0 && rng.gen_range(0..10) >= 7 {
         world.next_left = rng.gen_range(world.next_left-5..world.next_left+5)
@@ -108,18 +108,18 @@ fn main() -> std::io::Result<()> {
                     // I'm reading from keyboard into event
                     match event.code {
                         KeyCode::Char('q') => { break; },
-                        KeyCode::Char('w') => { 
+                        KeyCode::Char('w') => {
                             if world.player_l > 1 { world.player_l -= 1;}
                         },
-                        KeyCode::Char('s') => { 
+                        KeyCode::Char('s') => {
                             if world.player_l < maxl - 1 { world.player_l += 1;}
                         },
-                        KeyCode::Char('a') => { 
+                        KeyCode::Char('a') => {
                             if world.player_c > 1 { world.player_c -= 1;}
                         },
-                        KeyCode::Char('d') => { 
+                        KeyCode::Char('d') => {
                             if world.player_c < maxc - 1 { world.player_c += 1;}
-                        },                                                                        
+                        },
                         _ => {}
                     }
                 }
@@ -138,8 +138,10 @@ fn main() -> std::io::Result<()> {
 
     // game is finished
     sc.queue(Clear(crossterm::terminal::ClearType::All))?;
-    sc.queue(MoveTo(0, 3))?;
+    sc.queue(MoveTo(maxc / 2, maxl / 2))?;
     sc.queue(Print("Good game! Thanks.\n"))?;
+    thread::sleep(time::Duration::from_millis(3000));
+    sc.queue(Clear(crossterm::terminal::ClearType::All))?;
     sc.execute(Show)?;
     disable_raw_mode()?;
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ struct World {
     died: bool, // TODO: create enum with died, playing, animation, paused
     next_right: u16,
     next_left: u16,
+    ship: String
 }
 
 
@@ -31,7 +32,7 @@ fn draw(mut sc: &Stdout, world: &World) -> std::io::Result<()> {
 
     // draw the player
     sc.queue(MoveTo(world.player_c, world.player_l))?;
-    sc.queue(Print("P"))?;
+    sc.queue(Print(world.ship.as_str()))?;
 
     sc.flush()?;
 
@@ -95,6 +96,7 @@ fn main() -> std::io::Result<()> {
         died: false,
         next_left: maxc / 2 - 7,
         next_right: maxc / 2 + 7,
+        ship: '⛵'.to_string()
     };
 
     while !world.died {


### PR DESCRIPTION
In this commit, an end-of-game message with the text 'Good game! Thanks.' has been added to the game. This message is displayed upon completing the game and then cleared after a brief delay.

Changes:
- Implemented the 'Good game! Thanks.' message to appear at the center of the screen.
- Introduced a brief delay (3 seconds) before clearing the end-of-game message.

These changes enhance the user experience by providing a friendly acknowledgment at the end of the game.