### PR TITLE
Potential Fix for game panicing (cannot sample empty range ...)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -314,8 +314,8 @@ fn update_map(rng: &mut ThreadRng, world: &mut World) {
         }
     }
 
-    if world.next_right.abs_diff(world.next_left) < 3 {
-        world.next_right += 3;
+    if world.next_right.abs_diff(world.next_left) < 8 {
+        world.next_right += 8;
     }
     world.map.push_front((left, right))
 }


### PR DESCRIPTION
Closes #29 

I just played a bit around River's gap range ( distance between left side and right side )
and figured out after few minutes of running the game no errors happened !
so just increased the gap from 3 to 8. ( made it wider )
but I'm still not sure if it's working 100% or not
so dear @jadijadi may i ask you to please test this PR by your self ?
hope it will be working fine.