### PR TITLE
Quick solution to add styled contents.

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -72,7 +72,7 @@ impl Canvas {
         &mut self,
         loc: impl AsLocationTuple,
         display: impl Into<String>,
-        style: Option<ContentStyle>,
+        style: impl Into<Option<ContentStyle>> + Copy,
     ) -> &mut Canvas {
         let (c, l) = loc.as_loc_tuple();
         let string: String = display.into();
@@ -92,7 +92,7 @@ impl Canvas {
         &mut self,
         loc: impl AsLocationTuple,
         display: char,
-        style: Option<ContentStyle>,
+        style: impl Into<Option<ContentStyle>>,
     ) -> &mut Canvas {
         let (c, l) = loc.as_loc_tuple();
         self.acquire_block(c as usize, l as usize, display, style);
@@ -121,10 +121,10 @@ impl Canvas {
         c: usize,
         l: usize,
         new_char: char,
-        style: Option<ContentStyle>,
+        style: impl Into<Option<ContentStyle>>,
     ) {
         self.table[l][c] = Block::Acquired {
-            style,
+            style: style.into(),
             character: new_char,
         };
     }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -25,7 +25,7 @@ impl Display for Block {
             Block::Empty => f.write_char(' '),
             Block::Acquired { style, character } => {
                 if let Some(style) = style {
-                    StyledContent::new(style.clone(), character).fmt(f)
+                    StyledContent::new(*style, character).fmt(f)
                 } else {
                     f.write_char(*character)
                 }
@@ -78,7 +78,7 @@ impl Canvas {
         let string: String = display.into();
 
         for (offset, ch) in string.chars().enumerate() {
-            self.acquire_block((c as usize) + offset, l as usize, ch, style.clone());
+            self.acquire_block((c as usize) + offset, l as usize, ch, style);
         }
 
         self
@@ -100,6 +100,15 @@ impl Canvas {
         self
     }
 
+    pub fn draw_styled<D: Display>(
+        &mut self,
+        loc: impl AsLocationTuple,
+        content: impl Into<StyledContent<D>>,
+    ) -> &mut Canvas {
+        let content: StyledContent<D> = content.into();
+        self.draw_styled_line(loc, content.content().to_string(), Some(*content.style()))
+    }
+
     pub fn clear_all(&mut self) -> &mut Canvas {
         self.table = (0..self.mac_l)
             .map(|_| (0..self.max_c).map(|_| Block::Empty).collect())
@@ -119,10 +128,6 @@ impl Canvas {
             character: new_char,
         };
     }
-
-    // pub fn clear_block(&mut self, c: usize, l: usize) {
-    //     self.table[l][c] = Block::Empty
-    // }
 
     fn detect_changes(&self) -> Vec<(usize, usize)> {
         let mut changes: Vec<(usize, usize)> = vec![];

--- a/src/drawable.rs
+++ b/src/drawable.rs
@@ -13,7 +13,7 @@ impl Drawable for Enemy {
     fn draw(&self, sc: &mut Canvas) {
         match self.status {
             EntityStatus::Alive => {
-                sc.draw_styled_char(self, 'E', ContentStyle::new().red().into());
+                sc.draw_styled_char(self, 'E', ContentStyle::new().red());
             }
             EntityStatus::DeadBody => {
                 sc.draw_char(self, 'X');
@@ -27,7 +27,7 @@ impl Drawable for Fuel {
     fn draw(&self, sc: &mut Canvas) {
         match self.status {
             EntityStatus::Alive => {
-                sc.draw_styled_char(self, 'F', ContentStyle::new().green().into());
+                sc.draw_styled_char(self, 'F', ContentStyle::new().green());
             }
             EntityStatus::DeadBody => {
                 sc.draw_styled(self, '$'.yellow());
@@ -39,7 +39,7 @@ impl Drawable for Fuel {
 
 impl Drawable for Bullet {
     fn draw(&self, sc: &mut Canvas) {
-        sc.draw_styled_char(self, '|', None)
+        sc.draw_char(self, '|')
             .draw_char((self.location.c, self.location.l - 1), '^');
     }
 }

--- a/src/drawable.rs
+++ b/src/drawable.rs
@@ -1,3 +1,5 @@
+use crossterm::style::{ContentStyle, Stylize};
+
 use crate::{
     canvas::Canvas,
     entities::{Bullet, Enemy, EntityStatus, Fuel, Player},
@@ -11,7 +13,7 @@ impl Drawable for Enemy {
     fn draw(&self, sc: &mut Canvas) {
         match self.status {
             EntityStatus::Alive => {
-                sc.draw_char(self, 'E');
+                sc.draw_styled_char(self, 'E', ContentStyle::new().red().into());
             }
             EntityStatus::DeadBody => {
                 sc.draw_char(self, 'X');
@@ -25,7 +27,7 @@ impl Drawable for Fuel {
     fn draw(&self, sc: &mut Canvas) {
         match self.status {
             EntityStatus::Alive => {
-                sc.draw_char(self, 'F');
+                sc.draw_styled_char(self, 'F', ContentStyle::new().green().into());
             }
             EntityStatus::DeadBody => {
                 sc.draw_char(self, '$');
@@ -37,7 +39,7 @@ impl Drawable for Fuel {
 
 impl Drawable for Bullet {
     fn draw(&self, sc: &mut Canvas) {
-        sc.draw_char(self, '|')
+        sc.draw_styled_char(self, '|', None)
             .draw_char((self.location.c, self.location.l - 1), '^');
     }
 }

--- a/src/drawable.rs
+++ b/src/drawable.rs
@@ -30,7 +30,7 @@ impl Drawable for Fuel {
                 sc.draw_styled_char(self, 'F', ContentStyle::new().green().into());
             }
             EntityStatus::DeadBody => {
-                sc.draw_char(self, '$');
+                sc.draw_styled(self, '$'.yellow());
             }
             EntityStatus::Dead => {}
         };
@@ -46,6 +46,6 @@ impl Drawable for Bullet {
 
 impl Drawable for Player {
     fn draw(&self, sc: &mut Canvas) {
-        sc.draw_char(self, 'P');
+        sc.draw_styled(self, 'P'.blue());
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -19,59 +19,31 @@ pub fn handle_pressed_keys(world: &mut World) {
             Event::Key(event) => {
                 // I'm reading from keyboard into event
                 match event.code {
+                    KeyCode::Char('w') | KeyCode::Up
+                        if world.player.status == PlayerStatus::Alive
+                            && world.player.location.l > 1 =>
+                    {
+                        world.player.location.l -= 1
+                    }
+                    KeyCode::Char('s') | KeyCode::Down
+                        if world.player.status == PlayerStatus::Alive
+                            && world.player.location.l < world.maxl - 1 =>
+                    {
+                        world.player.location.l += 1
+                    }
+                    KeyCode::Char('a') | KeyCode::Left
+                        if world.player.status == PlayerStatus::Alive
+                            && world.player.location.c > 1 =>
+                    {
+                        world.player.location.c -= 1
+                    }
+                    KeyCode::Char('d') | KeyCode::Right
+                        if world.player.status == PlayerStatus::Alive
+                            && world.player.location.c < world.maxc - 1 =>
+                    {
+                        world.player.location.c += 1
+                    }
                     KeyCode::Char('q') => world.player.status = PlayerStatus::Quit,
-                    KeyCode::Char('w') => {
-                        if world.player.status == PlayerStatus::Alive && world.player.location.l > 1
-                        {
-                            world.player.location.l -= 1
-                        }
-                    }
-                    KeyCode::Char('s') => {
-                        if world.player.status == PlayerStatus::Alive
-                            && world.player.location.l < world.maxl - 1
-                        {
-                            world.player.location.l += 1
-                        }
-                    }
-                    KeyCode::Char('a') => {
-                        if world.player.status == PlayerStatus::Alive && world.player.location.c > 1
-                        {
-                            world.player.location.c -= 1
-                        }
-                    }
-                    KeyCode::Char('d') => {
-                        if world.player.status == PlayerStatus::Alive
-                            && world.player.location.c < world.maxc - 1
-                        {
-                            world.player.location.c += 1
-                        }
-                    }
-                    KeyCode::Up => {
-                        if world.player.status == PlayerStatus::Alive && world.player.location.l > 1
-                        {
-                            world.player.location.l -= 1
-                        }
-                    }
-                    KeyCode::Down => {
-                        if world.player.status == PlayerStatus::Alive
-                            && world.player.location.l < world.maxl - 1
-                        {
-                            world.player.location.l += 1
-                        }
-                    }
-                    KeyCode::Left => {
-                        if world.player.status == PlayerStatus::Alive && world.player.location.c > 1
-                        {
-                            world.player.location.c -= 1
-                        }
-                    }
-                    KeyCode::Right => {
-                        if world.player.status == PlayerStatus::Alive
-                            && world.player.location.c < world.maxc - 1
-                        {
-                            world.player.location.c += 1
-                        }
-                    }
                     KeyCode::Char('p') if event.kind == KeyEventKind::Press => {
                         use crate::WorldStatus::*;
                         world.status = match world.status {

--- a/src/world/drawings.rs
+++ b/src/world/drawings.rs
@@ -35,7 +35,7 @@ impl World {
                 .draw_line((map_c, l as u16), "+".repeat((maxc - map_c) as usize));
         }
 
-        let status_style = Some(ContentStyle::new().black().on_white());
+        let status_style = ContentStyle::new().black().on_white();
         let gas_present = self.player.gas / 100;
         let enemies_count = self.enemies.len();
         self.canvas

--- a/src/world/drawings.rs
+++ b/src/world/drawings.rs
@@ -4,7 +4,10 @@ use std::{
     time::Duration,
 };
 
-use crossterm::event::{poll, read};
+use crossterm::{
+    event::{poll, read},
+    style::{ContentStyle, Stylize},
+};
 
 use crate::{
     entities::{DeathCause, PlayerStatus},
@@ -32,12 +35,17 @@ impl World {
                 .draw_line((map_c, l as u16), "+".repeat((maxc - map_c) as usize));
         }
 
+        let status_style = Some(ContentStyle::new().black().on_white());
         let gas_present = self.player.gas / 100;
         let enemies_count = self.enemies.len();
         self.canvas
-            .draw_line(2, format!(" Score: {} ", self.player.score))
-            .draw_line((2, 3), format!(" Fuel: {} ", gas_present))
-            .draw_line((2, 4), format!(" Enemies: {} ", enemies_count));
+            .draw_styled_line(2, format!(" Score: {} ", self.player.score), status_style)
+            .draw_styled_line((2, 3), format!(" Fuel: {} ", gas_present), status_style)
+            .draw_styled_line(
+                (2, 4),
+                format!(" Enemies: {} ", enemies_count),
+                status_style,
+            );
 
         // draw fuel
         for fuel in self.fuels.iter() {


### PR DESCRIPTION
Added `style: ContentStyle` to the canvas's block to store style for each block.

Methods `draw_styled_char` and `draw_styled_line` are now available in `Canvas`.

Here is how you can add style to a char (or line).
```rust
sc.draw_styled_char(self, 'E', ContentStyle::new().red().into());

self.canvas
    .draw_styled_line(2, format!(" Score: {} ", self.player.score), ContentStyle::new().black().on_white().into())
```